### PR TITLE
Use connection timeout rather than request timeout for skylight.fetch

### DIFF
--- a/bootstrap/skylight_bootstrap/http.ex
+++ b/bootstrap/skylight_bootstrap/http.ex
@@ -7,7 +7,7 @@ defmodule SkylightBootstrap.HTTP do
   @spec get(binary) :: {:ok, binary} | {:error, term}
   def get(url) do
     request = {to_char_list(url), []}
-    http_opts = [timeout: 10_000, autoredirect: true]
+    http_opts = [connect_timeout: 10_000, autoredirect: true]
     opts      = [body_format: :binary]
 
     case :httpc.request(:get, request, http_opts, opts) do


### PR DESCRIPTION
skylight.fetch was timing out on my machine (taking longer than 10 seconds to download the native files). When investigating it looks like the wrong :httpc timeout was used (request rather than connection). Changed to use the connection timeout.