### PR TITLE
Fetch Skylight native assets when compiling

### DIFF
--- a/bootstrap/skylight_bootstrap.ex
+++ b/bootstrap/skylight_bootstrap.ex
@@ -107,7 +107,7 @@ defmodule SkylightBootstrap do
           err -> err
         end
       {:error, reason} ->
-        {:error, "failed to fetch from #{source_url}: #{inspect reason}"}
+        {:error, "Failed to fetch Skylight native artifacts from #{source_url}: #{inspect reason}"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,10 @@ defmodule Mix.Tasks.Compile.Skylight do
       compile_c_code()
     else
       # TODO make this message way nicer
-      Mix.shell.error "Run `mix skylight.fetch`"
+      # Mix.shell.error "Run `mix skylight.fetch`"
+      :ok = SkylightBootstrap.fetch()
+      :ok = SkylightBootstrap.extract_and_move()
+      compile_c_code()
     end
 
     :ok

--- a/mix.exs
+++ b/mix.exs
@@ -55,11 +55,7 @@ defmodule Skylight.Mixfile do
   end
 
   defp elixirc_paths do
-    if SkylightBootstrap.artifacts_already_exist? do
-      ~w(lib bootstrap/mix/tasks)
-    else
-      ~w(bootstrap/mix/tasks)
-    end
+    ~w(lib bootstrap/mix/tasks)
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -6,16 +6,12 @@ defmodule Mix.Tasks.Compile.Skylight do
   @shortdoc "Fetches Skylight binaries and compiles native C code"
 
   def run(_args) do
-    if SkylightBootstrap.artifacts_already_exist? do
-      :ok = SkylightBootstrap.extract_and_move()
-      compile_c_code()
-    else
-      # TODO make this message way nicer
-      # Mix.shell.error "Run `mix skylight.fetch`"
+    unless SkylightBootstrap.artifacts_already_exist? do
       :ok = SkylightBootstrap.fetch()
-      :ok = SkylightBootstrap.extract_and_move()
-      compile_c_code()
     end
+
+    :ok = SkylightBootstrap.extract_and_move()
+    compile_c_code()
 
     :ok
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cowboy": {:hex, :cowboy, "1.0.3", "101a5f826ce9a1ebb2ea53a2cdfffc74736e99807e9e492ecd5f26544c04082b", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+%{"cowboy": {:hex, :cowboy, "1.0.3", "101a5f826ce9a1ebb2ea53a2cdfffc74736e99807e9e492ecd5f26544c04082b", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.1", "175a633c472058bbeb1b238a6409766a48b52b43b7b687ed70f03cf6e854b7d9", [:make], []},
   "decimal": {:hex, :decimal, "1.1.0", "3333732f17a90ff3057d7ab8c65f0930ca2d67e15cca812a91ead5633ed472fe", [:mix], []},
   "ecto": {:hex, :ecto, "1.0.6", "c1831d44a9f4124f12306a3bf88c65fdd41cb64be69d389774630983e831304a", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.4.1", [hex: :mariaex, optional: true]}, {:poison, "~> 1.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.9.1", [hex: :postgrex, optional: true]}, {:sbroker, "~> 0.7", [hex: :sbroker, optional: true]}]},

--- a/test/bootstrap/skylight_bootstrap_test.exs
+++ b/test/bootstrap/skylight_bootstrap_test.exs
@@ -42,7 +42,7 @@ defmodule SkylightBootstrapTest do
 
     capture_log fn ->
       assert {:error, error} = SB.fetch()
-      assert String.starts_with?(error, "failed to fetch from")
+      assert String.starts_with?(error, "Failed to fetch Skylight native artifacts from")
       assert String.ends_with?(error, ":an_error")
     end
   end


### PR DESCRIPTION
When previously compiling if the native Skylight assets were not present then only the bootstrap files for the Skylight app would be compiled with a message prompting to download the native assets using mix skylight.fetch. This had the following issues:

- Running mix skylight.fetch would download to the local project directory rather than the Skylight dependency directory meaning the native assets would never be available
- Elixir considers the Skylight app as compiled, so any other time you try to compile (mix compile/mix phoenix.server/mix test etc) Skylight is never recompiled with the native assets so is never available in your app. The only workaround for this is to run mix deps.compile or something similar to force a compile

This pull request then changes compiling the Skylight app so it downloads, extracts and compiles the native assets to fix all the above issues. Additionally, if any of these critical steps cannot be completed then the elixir compile explicitly fails so the recompile issues don't arise.